### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -58,28 +58,28 @@ jobs:
         shell: bash
         run: |
           # Validate Action Output
-          if [ "${{ steps.semver.outputs.tag }}" \
+          if [ "${STEPS_SEMVER_OUTPUTS_TAG}" \
             != 'v0.1.1' ]; then
             echo 'Error: did not get expected semantic tag result ❌'
-            echo "Returned: ${{ steps.semver.outputs.tag }}"
+            echo "Returned: ${STEPS_SEMVER_OUTPUTS_TAG}"
             echo 'Expected: v0.1.1'
             errors='true'
-          elif [ "${{ steps.semver.outputs.tag_count }}" \
+          elif [ "${STEPS_SEMVER_OUTPUTS_TAG_COUNT}" \
             != '2' ]; then
             echo 'Error: did not get expected semver count ❌'
-            echo "Returned: ${{ steps.semver.outputs.tag_count }}"
+            echo "Returned: ${STEPS_SEMVER_OUTPUTS_TAG_COUNT}"
             echo 'Expected: 2'
             errors='true'
-          elif [ "${{ steps.calver.outputs.tag }}" \
+          elif [ "${STEPS_CALVER_OUTPUTS_TAG}" \
             != '2025.02.01' ]; then
             echo 'Error: did not get expected calver tag result ❌'
-            echo "Returned: ${{ steps.calver.outputs.tag }}"
+            echo "Returned: ${STEPS_CALVER_OUTPUTS_TAG}"
             echo 'Expected: 2025.02.01'
             errors='true'
-          elif [ "${{ steps.calver.outputs.tag_count }}" \
+          elif [ "${STEPS_CALVER_OUTPUTS_TAG_COUNT}" \
             != '2' ]; then
             echo 'Error: did not get expected calver count ❌'
-            echo "Returned: ${{ steps.calver.outputs.tag_count }}"
+            echo "Returned: ${STEPS_CALVER_OUTPUTS_TAG_COUNT}"
             echo 'Expected: 2'
             errors='true'
           fi
@@ -90,3 +90,8 @@ jobs:
           else
             echo 'Action validation passed ✅'
           fi
+        env:
+          STEPS_SEMVER_OUTPUTS_TAG: ${{ steps.semver.outputs.tag }}
+          STEPS_SEMVER_OUTPUTS_TAG_COUNT: ${{ steps.semver.outputs.tag_count }}
+          STEPS_CALVER_OUTPUTS_TAG: ${{ steps.calver.outputs.tag }}
+          STEPS_CALVER_OUTPUTS_TAG_COUNT: ${{ steps.calver.outputs.tag_count }}

--- a/action.yaml
+++ b/action.yaml
@@ -188,13 +188,16 @@ runs:
       # yamllint disable rule:line-length
       run: |
         # Report tag format/type
-        if [ "${{ steps.semantic-check.outputs.valid }}" = 'true' ]; then
+        if [ "${STEPS_SEMANTIC_CHECK_OUTPUTS_VALID}" = 'true' ]; then
           echo 'Current/latest repository tag is semantic ✅' >> "$GITHUB_STEP_SUMMARY"
           echo 'Current/latest repository tag is semantic ✅'
-        elif [ "${{ steps.calver-check.outputs.valid }}" = 'true' ]; then
+        elif [ "${STEPS_CALVER_CHECK_OUTPUTS_VALID}" = 'true' ]; then
           echo 'Current/latest repository tag uses calver ✅' >> "$GITHUB_STEP_SUMMARY"
           echo 'Current/latest repository tag uses calver ✅'
         else
           echo 'Could not identify tag type ⚠️' >> "$GITHUB_STEP_SUMMARY"
           echo 'Could not identify tag format/type ⚠️'
         fi
+      env:
+        STEPS_SEMANTIC_CHECK_OUTPUTS_VALID: ${{ steps.semantic-check.outputs.valid }}
+        STEPS_CALVER_CHECK_OUTPUTS_VALID: ${{ steps.calver-check.outputs.valid }}


### PR DESCRIPTION
## Why

`zizmor`'s `template-injection` audit reports GitHub expressions that expand directly inside `run:` blocks. The expansion happens *before* the shell sees the script, so a value carrying shell syntax becomes code rather than data.

Each expression now reaches the shell through the step environment instead. These findings predate the change to the organisation `zizmor` floor (`low` → `informational`); they were simply below the old threshold.

## Please review the diff carefully

The transformation is not purely mechanical. Swapping `${{ expr }}` for `${VAR}` **changes the quoting rules**, because the original was substituted by GitHub before the shell ran and the replacement is an ordinary shell variable. Three contexts silently stop working:

| Context | Before | After |
| ------- | ------ | ----- |
| `var='${{ expr }}'` | substituted by GitHub | **literal string** |
| `echo 'text ${{ expr }}'` | substituted by GitHub | **literal string** |
| `cat <<'EOF'` … `${{ expr }}` | substituted by GitHub | **literal string** |

`shellcheck` catches the first two. **It does not catch the heredoc case.** That one was found in `url-validity-action`, where 27 references would have rendered the job summary as variable names instead of results.

## What was verified before raising this

- `zizmor --persona auditor --min-severity informational` — no findings
- `actionlint` (including shellcheck) — clean
- `yamllint` — clean
- A purpose-built audit for generated variables landing in single quotes or quoted heredocs — clean. It was validated by confirming it detects 33 such problems in the unrepaired output for `url-validity-action`.
- Diff restricted to workflow and action definitions; no `dependabot.yml` or version-pin comment changes rode along

## Note on the generated names

Where `zizmor`'s names push a line past the length limit, the line carries a `yamllint disable-line` directive. Shortening them was rejected: the short forms are unique only *within* one `env:` block, so a global rewrite merges distinct variables and leaves dangling references — verified by observing exactly that failure.
